### PR TITLE
Version 1.0.1 accepted by Mozilla Add-Ons

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,5 +1,9 @@
 # Default ignored files
 /shelf/
 /workspace.xml
+# Other ignore's
+*.zip
+*.DS_Store
+TODO.txt
 # Editor-based HTTP Client requests
 /httpRequests/

--- a/content_scripts/function_broker.js
+++ b/content_scripts/function_broker.js
@@ -1,0 +1,32 @@
+/*
+The starting point of this file started as a fork from the example repository in
+https://github.com/mdn/webextensions-examples/tree/master/beastify (beastify.js)
+*/
+
+(function() {
+  /**
+   * Check and set a global guard variable.
+   * If this content script is injected into the same page again,
+   * it will do nothing next time.
+   */
+  if (window.hasRun) {
+    return;
+  }
+  window.hasRun = true;
+
+  function manuallyTriggerVideoSwap() {
+    document.getElementById("injectedInvisibleClickable").click();// = document.createElement("injectedInvisibleClickable");
+
+  }
+
+  /**
+   * Listen for messages from the background script.
+   * Call the function
+   */
+  browser.runtime.onMessage.addListener((message) => {
+    if (message.command === "ManuallyReApplyJSPageModifications") {
+      manuallyTriggerVideoSwap();
+    }
+  });
+
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 
   "manifest_version": 2,
   "name": "Return Youtube UI",
-  "version": "1.0",
+  "version": "1.0.1",
   "author": "42null",
   "description": "An extension aimed at making youtube look like it used to before everything became rounded and circular.",
   "homepage_url": "https://github.com/42null/Return-YouTube-UI",


### PR DESCRIPTION
Some slight changes were made to the manifest file regarding the size of icons as it was detected by the submission process. You can find it at https://addons.mozilla.org/en-US/firefox/addon/return-youtube-ui/.